### PR TITLE
Feature/pages　map内に展開した個別のノートのdateの値を取り出して、違うページに持っていきたい

### DIFF
--- a/frontend/src/pages/Top.tsx
+++ b/frontend/src/pages/Top.tsx
@@ -53,6 +53,16 @@ export const TopPage:VFC =memo(()=>{
     })
     .catch((e)=> console.log(e))
   }
+  const onClickUpdateButton =()=>{
+    axios
+    .get(`http://localhost:3000/api/v1/kids/${kidId}/communication_notebooks`)
+    .then((res)=>{
+      setAllNotebooks(res.data)
+      console.log(allNotebooks)
+    })
+    .catch((e)=> console.log(e))
+  }
+
   const handleDateChange = (date: Date | null ) => {
     setSelectedDate(date)
     console.log(date)
@@ -103,7 +113,7 @@ export const TopPage:VFC =memo(()=>{
         <SimpleAlerts status={status} label={label} />
         {allNotebooks.map((allNotebook)=>(
           <Box>
-            <Button color="primary" variant="contained" onClick={onClickPastButton}>{allNotebook.date}のノートを表示</Button>
+            <Button color="primary" variant="contained" onClick={{allNotebook}=>onClickUpdateButton}>{allNotebook.date}のノートを表示</Button>
           </Box>
         ))}
       </>

--- a/frontend/src/pages/Top.tsx
+++ b/frontend/src/pages/Top.tsx
@@ -53,14 +53,9 @@ export const TopPage:VFC =memo(()=>{
     })
     .catch((e)=> console.log(e))
   }
-  const onClickUpdateButton =()=>{
-    axios
-    .get(`http://localhost:3000/api/v1/kids/${kidId}/communication_notebooks`)
-    .then((res)=>{
-      setAllNotebooks(res.data)
-      console.log(allNotebooks)
-    })
-    .catch((e)=> console.log(e))
+
+  const onClickUpdateButton =(date:Date)=>{
+    history.push({pathname:"/registration", state: date})
   }
 
   const handleDateChange = (date: Date | null ) => {
@@ -113,7 +108,7 @@ export const TopPage:VFC =memo(()=>{
         <SimpleAlerts status={status} label={label} />
         {allNotebooks.map((allNotebook)=>(
           <Box>
-            <Button color="primary" variant="contained" onClick={{allNotebook}=>onClickUpdateButton}>{allNotebook.date}のノートを表示</Button>
+            <Button color="primary" variant="contained" onClick={(allNotebook.date)=>onClickUpdateButton}>{allNotebook.date}のノートを表示</Button>
           </Box>
         ))}
       </>


### PR DESCRIPTION
### 前提
allNotebooksには過去に記録した全ての連絡帳のデータが入っています。allNotebook.dateには個々のノートがいつのノートなのかという日付が入っています。
Buttonを押すと該当する日付のノートの更新画面に遷移するという流れにしたいです
### 現状
map内の
`<Button color="primary" variant="contained" onClick={(allNotebook.date)=>onClickUpdateButton}>{allNotebook.date}のノートを表示</Button>`
にある
onClick={(allNotebook.date)=>onClickUpdateButton}のところでエラーがでます。
原因はallNotebook.dateはDate型なのに、実際にはMouseEventHandler<HTMLAnchorElement>という型が要求されているからだと思われます。
しかし、どうにかしてallNotebook.dateの値をRegistrationページに持っていきたいです。
そのためにallNotebook.dateの値をhistory.pushにのせてページ遷移しようとしていました（onClickUpdateButton）。

この状況下で、先述のtypeエラーを乗り越える方法　or  違う方法で、allNotebook.dateを他のページに渡す方法があればアドバイス欲しいです